### PR TITLE
Add basic IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-.svn
-build
-dist
 *~
 *#
 *.fasl
 *.pyc
+.svn
+build
+dist
+tags

--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # cl-cidr-notation
 
-A Common Lisp library for converting ip addresses and CIDR blocks
-from integer to string representations and vice versa
+A Common Lisp library for converting IP addresses and CIDR blocks from integer to string representations, and vice versa.
 
-The functions are optimized for speed.
+The IPv4 functions are optimized for speed.
 
-EG: "1.2.3.4" => 16909060 , 32
-EG: "1.2.3.4/30" => 16909060 , 30
+EG:
+"1.2.3.4" => 16909060, 32
+"1.2.3.4/30" => 16909060 , 30
+"::1" => 1, 128
+"cafe:beef::/64" => 269826771143976387270773007078999982080, 64
 
 This library was spawned by this paste: http://paste.lisp.org/display/139246
 
-## cidr-string, ip-string
+## cidr-string, ip-string, ipv6-string
 
-Convert integers to strings
+Convert integers to strings.
 
 ## range-string
 
-Given two integer ips, produce a "0.0.0.0-0.0.0.1" representation
+Given two integer IPv4 addresses, produce a "0.0.0.0-0.0.0.1" representation.
 
-## parse-cidr, parse-ip 
+## parse-cidr, parse-ip, parse-ipv6-cidr, parse-ipv6
 
-Convert strings into integers, throwing meaningful cidr-parse-error if
-it fails
+Convert strings into integers, throwing meaningful cidr-parse-error on failure.
 
 
-## Speed Results
-This is probably not super meaningful, but at least gives some benchmarks for the current speeds Im seeing
+## Speed Results for IPv4 conversions
+This is probably not super meaningful, but at least gives some benchmarks for the current speeds I'm seeing
 
 ```
 CL-CIDR-NOTATION-TEST> (time (loop for i from 0 below (expt 2 32) by (expt 2 8)
@@ -53,3 +54,4 @@ Evaluation took:
  * Stas Boukarev - stassats @ #lisp - super optimization work
  * Russ Tyndall - Acceleration.net
  * Nathan Bird - Acceleration.net
+ * James Fleming - james@electronic-quill.net - unoptimised IPv6 additions

--- a/cl-cidr-notation.asd
+++ b/cl-cidr-notation.asd
@@ -26,7 +26,8 @@
                         :serial t
                         :components ((:file "packages")
                                      (:file "cl-cidr-notation"))))
-  :depends-on (:cl-cidr-notation :lisp-unit2))
+  :depends-on (:cl-cidr-notation
+               :lisp-unit2))
 
 (defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :cl-cidr-notation))))
   (asdf:oos 'asdf:load-op :cl-cidr-notation-test)

--- a/cl-cidr-notation.asd
+++ b/cl-cidr-notation.asd
@@ -9,18 +9,20 @@
 (defsystem :cl-cidr-notation
   :description "A library providing functions to read and write CIDR IP address notation"
   :licence "BSD"
-  :version "0.1"
+  :version "0.2"
   :serial t
   :components ((:module :src
                 :serial t
                 :components ((:file "packages")
-                             (:file "cl-cidr-notation"))))
-  :depends-on (:symbol-munger ))
+                             (:file "cl-cidr-notation")
+                             (:file "cl-ipv6-notation"))))
+  :depends-on (:cl-ppcre
+               :symbol-munger))
 
 (defsystem :cl-cidr-notation-test
   :description "Tests for the cl-cidr-notation library"
   :licence "BSD"
-  :version "0.1"
+  :version "0.2"
   :serial t
   :components ((:module :test
                         :serial t

--- a/src/cl-ipv6-notation.lisp
+++ b/src/cl-ipv6-notation.lisp
@@ -1,0 +1,165 @@
+(in-package :cl-cidr-notation)
+
+;;;; IPv6 string <--> integer functions
+
+(defun hex-char-p (cha)
+  "Check whether a character is a valid hexadecimal one.
+   Return a boolean"
+  (when
+    (or (digit-char-p cha)
+        (member cha (list #\a #\b #\c #\d #\e #\f #\A #\B #\C #\D #\E #\F)))
+    t))
+
+;;; FIXME Replace tokenise-ipv6-basic with this, once it's working
+#+(or)
+(defun ipv6-string-parser (ipv6-string
+                            &key (index 0) ; pointer into the array
+                            chunks ; Accumulator for the parsed chunks
+                            str    ; Accumulator for the string being built
+                            colonp ; Boolean indicating whether the last char was a colon
+                            (num-before-dc 0) ; The number of chunks parsed before ::
+                            dc-found-p ; Boolean indicating whether we've already found a ::
+                            )
+  "Parses an IPv6 string into chunks, plus a count of the chunks parsed before encountering ::
+   Return a two-element list:
+   - the accumulated chunks
+   - the number of chunks represented by ::"
+  (cond
+    ;; End of the string.
+    ;; Finish processing and pass it back
+    ;; FIXME: write the actual code
+    ((= index (length ipv6-string))
+     (error "Actual code goes here"))
+    ;; String starts with a colon
+    ((and (equal index 0)
+          (equal (aref ipv6-string index) #\:))
+     (ipv6-string-parser ipv6-string
+                         :index 1
+                         :colonp t))
+    ;; Found a double-colon
+    ((and colonp
+          (equal (aref ipv6-string index) #\:))
+     (ipv6-string-parser ipv6-string
+                         :index (+ index 1)
+                         :colonp t
+                         :chunks chunks
+                         :dc-found-p t))
+    ((hex-char-p (aref ipv6-string index))
+     (ipv6-string-parser ipv6-string
+                         :index (+ index 1)))
+    ;; Catch-all fallback
+    (t
+     (error "Unhandled state"))))
+
+(defun ipv6-chunks-to-int (chunks ; Remaining chunks to parse
+                            acc   ; Accumulator for the result
+                            zero-length   ; Number of consecutive zero-chunks
+                            chunks-done)  ; Number of chunks processed so far
+  "Interpret the parsed chunks of an IPv6 string, and return an integer."
+  ;; Have we already hit the end of the list?
+  (if chunks
+      ;; Not at the end of the list yet
+      ;; First check: is this where the :: appears?
+      (if (null (car chunks))
+          ;; This is where the :: appears.
+          ;; Reduce zero-length to 0, to stop left-shifting things to its right
+          (progn
+            (ipv6-chunks-to-int (cdr chunks) acc 0 (+ chunks-done zero-length)))
+          ;; Not the :: section. Parse as a hex section.
+          (progn
+            (ipv6-chunks-to-int
+              (cdr chunks)
+              ;; This is where the fun stuff happens:
+              ;; - read the string as a number in hexadecimal notation
+              ;; - left-shift it by a suitable amount
+              ;; - add that result to the accumulator
+              (logior acc
+                      (ash (parse-integer (car chunks) :radix 16)
+                           (* 16 (- 7 chunks-done))))
+              ;; Just pass this on through until it's needed
+              zero-length
+              ;; Increment the number of chunks processed
+              (+ chunks-done 1))))
+      ;; If we've hit the end, return the accumulator
+      acc))
+
+(defun tokenise-ipv6-basic (ipv6-string)
+  "Naive approach to parsing an IPv6 string.
+   Return a list of the chunks making up the string, with :: represented by a NIL element."
+  (let ((string-parts (cl-ppcre:split ":" ipv6-string)))
+    ;; Strings beginning with :: are split into a list with a spurious leading ""
+    ;; so remove it.
+    (substitute nil
+                ""
+                (if (equal (char ipv6-string 0) #\:)
+                    (cdr string-parts)
+                    string-parts)
+                :test #'equal)))
+
+(defun parse-ipv6 (ipv6-string)
+  "Somewhat basic approach to parsing an IPv6 string."
+  (let ((chunks (tokenise-ipv6-basic ipv6-string)))
+    (ipv6-chunks-to-int
+      chunks
+      0
+      ;; Calculate the number of zero-chunks represented by ::, if anything
+      (- 8 (length (remove-if #'null chunks)))
+      0)))
+
+(defun parse-ipv6-cidr (cidrstr)
+  "Transform an IPv6 string such as cafe:beef::/64 into a pair of integers
+   representing the network address and the prefix-length.
+   If a bare address is given, assert the prefix-length as 128."
+  (let* ((slash (position #\/ cidrstr))
+         (addr (subseq cidrstr 0 slash))
+         (prefixlength
+           (if slash
+               (parse-integer (subseq cidrstr (+ slash 1)) :junk-allowed nil)
+               128)))
+    (values (cl-cidr-notation:parse-ipv6 addr)
+            prefixlength)))
+
+(defun ipv6-string (int)
+  "Simple approach to rendering an integer in canonical IPv6 string format.
+   Does not strip leading zeros, or replace repeated sections of zeros with ::."
+  (string-downcase ;; Because :case :downcase doesn't work in SBCL
+    (with-output-to-string (outstr)
+      (write (ldb (byte 4 124) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 120) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 116) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 112) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 108) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 104) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 100) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 96) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 92) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 88) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 84) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 80) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 76) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 72) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 68) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 64) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 60) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 56) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 52) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 48) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 44) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 40) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 36) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 32) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 28) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 24) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 20) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 16) int) :base 16 :stream outstr)
+      (write ":" :stream outstr :escape nil)
+      (write (ldb (byte 4 12) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 8) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 4) int) :base 16 :stream outstr)
+      (write (ldb (byte 4 0) int) :base 16 :stream outstr))))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -2,6 +2,12 @@
   (:use #:cl-user #:cl)
   (:export
    #:cidr-parse-error
-   #:ip-string #:cidr-string #:range-string
-   #:parse-ip #:parse-cidr
-   #:valid-cidr? ))
+   #:cidr-string
+   #:ip-string
+   #:ipv6-string
+   #:parse-cidr
+   #:parse-ipv6-cidr
+   #:parse-ip
+   #:parse-ipv6
+   #:range-string
+   #:valid-cidr?))

--- a/test/cl-cidr-notation.lisp
+++ b/test/cl-cidr-notation.lisp
@@ -37,3 +37,30 @@
   (assert-equal
    "0.0.1.255-0.0.4.128"
    (range-string 511 1152)))
+
+
+;;; IPv6
+
+(define-test basic-ipv6 ()
+  ;; Loopback address
+  (assert-equal 1 (parse-ipv6 "::1"))
+  ;; Network address
+  (assert-equal "cafe:beef:0000:0000:0000:0000:0000:0000"
+                (ipv6-string
+                  (parse-ipv6 "cafe:beef::")))
+  ;; Regular address
+  (assert-equal "cafe:beef:0000:0000:0000:0000:0000:0001"
+                (ipv6-string
+                  (parse-ipv6 "cafe:beef::1")))
+  ;; Subnet
+  (multiple-value-bind (int prefix)
+    (parse-ipv6-cidr "cafe:beef::/64")
+    (assert-equal "cafe:beef:0000:0000:0000:0000:0000:0000"
+                  (ipv6-string int))
+    (assert-equal 64 prefix))
+  ;; Interface address
+  (multiple-value-bind (int prefix)
+    (parse-ipv6-cidr "cafe:beef::1")
+    (assert-equal "cafe:beef:0000:0000:0000:0000:0000:0001"
+                  (ipv6-string int))
+    (assert-equal 128 prefix)))

--- a/test/cl-cidr-notation.lisp
+++ b/test/cl-cidr-notation.lisp
@@ -1,20 +1,32 @@
 (in-package :cl-cidr-notation-test)
 
+
+;;; IPv4
+
 (define-test basic-tests ()
-  (let ((ips (list "0.0.0.0" "0.0.0.0/24" "0.0.0.128/29"
-                   "1.12.123.255" "255.255.255.255"
-                   "128.128.128.128/29" "0.0.0.0/1"
+  (let ((ips (list "0.0.0.0"
+                   "0.0.0.0/24"
+                   "0.0.0.0/1"
                    "0.0.0.0/31"
-                   )))
+                   "0.0.0.128/29"
+                   "1.12.123.255"
+                   "128.128.128.128/29"
+                   "255.255.255.255")))
     (loop for i in ips
           do (multiple-value-bind (s f) (parse-cidr i)
                (assert-equal i (cidr-string s f))))))
 
 (define-test failures ()
-  (let ((ips (list "0.0.0.1/30" "0.0.0.1/31"
-                   "0.0.0.1/20" "asdasd" "256.1.1.1"
-                   "1.255.1.1.1" ".255.1.1.1"
-                   "255.1.1.1." "0.0.0.0." "0.0.0.0/"  )))
+  (let ((ips (list "0.0.0.0."
+                   "0.0.0.0/"
+                   "0.0.0.1/30"
+                   "0.0.0.1/31"
+                   "0.0.0.1/20"
+                   "asdasd"
+                   "256.1.1.1"
+                   "1.255.1.1.1"
+                   ".255.1.1.1"
+                   "255.1.1.1.")))
     (loop for i in ips
           do (assert-error 'cidr-parse-error (parse-cidr i)))))
 


### PR DESCRIPTION
I needed to manipulate IPv6 addresses, so I extended this wonderfully efficient library with... well, code that works.

I also took the liberty of lightly reformatting some of the existing code, to make it easier to read and reason through. No functional changes; just things like giving variables less-ambiguous names, and breaking lists up over multiple lines to make them easier to scan visually.

If the indentation in the new code looks odd, it'll be because I use Vim.

There _is_ somewhat more efficient code to come, mainly in the string-parsing, and I've yet to add a version of `ipv6-string` that compacts the output, but I'd rather offer it upstream in a basic working form, rather than holding out for perfection.